### PR TITLE
ignore desired capacity changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Fork
+
+- ignores changes to `desired_capacity` because TargetTracking policies will change this value outside of Terraform.
+
 # AWS Auto Scaling Group (ASG) Terraform module
 
 Terraform module which creates Auto Scaling resources on AWS.

--- a/main.tf
+++ b/main.tf
@@ -110,6 +110,7 @@ resource "aws_autoscaling_group" "this" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes        = [desired_capacity]
   }
 }
 
@@ -176,6 +177,7 @@ resource "aws_autoscaling_group" "this_with_initial_lifecycle_hook" {
 
   lifecycle {
     create_before_destroy = true
+    ignore_changes        = [desired_capacity]
   }
 }
 


### PR DESCRIPTION
Ignore desired_capacity because non-Terraform systems will be changing the desired_capacity setting: ASG TargetTracking, self-service, AWS console...

When merged, this will be tagged v3.6.0-scalyr1
