### PR TITLE
OPS-5933: tf 0.14 compatible versions.tf

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,16 @@
 terraform {
-  required_version = ">= 0.12.6, < 0.14"
+  required_version = ">= 0.13"
 
   required_providers {
-    aws = ">= 2.41, < 4.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.41, < 4.0"
+    }
+    null = {
+      source = "hashicorp/null"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
   }
 }


### PR DESCRIPTION
Ran `terraform 0.13upgrade` to update versions.tf with Terraform and provider config.

This should not be merged until the TF 0.14 upgrade is started and every use has a pinned version.